### PR TITLE
Replace fatalError by super.frame call in LineLayer

### DIFF
--- a/TastyTomato/Code/Classes/LayerClasses/LineLayer.swift
+++ b/TastyTomato/Code/Classes/LayerClasses/LineLayer.swift
@@ -96,7 +96,7 @@ public class LineLayer: CAShapeLayer {
     // MARK: Unavailability Overrides
     @available(*, unavailable)
     public override var frame: CGRect {
-        get { fatalError() }
+        get { return super.frame }
         set { fatalError() }
     }
     


### PR DESCRIPTION
This error crashes the View Debugger, which logically seems to retrieve
the frame from each view.